### PR TITLE
support `arm64` chroot on `amd64` host

### DIFF
--- a/chroot/__init__.py
+++ b/chroot/__init__.py
@@ -102,7 +102,8 @@ class MagicMounts:
                  mnt_profile: list[tuple[str, str, str]],
                  root: str = "/",
                  ):
-        self.profile = mnt_profile if mnt_profile else MNT_DEFAULT
+        #self.profile = mnt_profile if mnt_profile else MNT_DEFAULT
+        self.profile = MNT_FULL
         root = os.fspath(abspath(root))
         self.qemu_arch_static = ()
 
@@ -121,6 +122,8 @@ class MagicMounts:
                 qemu_arch_bin = "usr/bin/qemu-aarch64-static"
                 self.qemu_arch_static = (f"/{qemu_arch_bin}",
                                         join(root, qemu_arch_bin))
+        elif host_arch:
+            self.profile = MNT_FULL
 
         self.paths = ()
         self.mounted: dict[str, bool] = {}

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Standards-Version: 4.0.0
 X-Python-Version: >= 3.5
 
 Package: turnkey-chroot
-Architecture: any
+Architecture: all
 Depends:
  ${misc:Depends},
  ${python3:Depends},


### PR DESCRIPTION
After planning to copy `/usr/bin/qemu-arm-static` into the chroot, I read on the Debian wiki that it could be mounted instead. So I think what I've done here is probably the cleanest (and simplest) way to go?

I still need to make sure that it actually works, but I'd like your thoughts @OnGle.