### PR TITLE
fix: MNT_DEFAULT dict mutated across Chroot instances

### DIFF
--- a/chroot/__init__.py
+++ b/chroot/__init__.py
@@ -202,7 +202,7 @@ class Chroot:
                 "/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/bin:/usr/sbin",
         }
         self.environ.update(environ)
-        self.profile = MNT_DEFAULT if not mnt_profile else mnt_profile
+        self.profile = dict(MNT_DEFAULT) if not mnt_profile else dict(mnt_profile)
 
         self.path: str = realpath(os.fspath(newroot))
         self.magicmounts = MagicMounts(self.profile, self.path)


### PR DESCRIPTION
## Summary

`Chroot.__init__()` passes `MNT_DEFAULT` (a module-level dict) directly to `MagicMounts.__init__()`, which calls `mnt_profile.pop("switch")` — mutating the global dict. On the second `Chroot` instantiation in the same process, `MNT_DEFAULT` no longer has the `"switch"` key, causing a `KeyError`.

## When this happens

`fab-install` creates two `Chroot` instances in the same process:
- `PoolInstaller(chroot_path, pool_path, arch, environ)` → `Chroot()`
- `LiveInstaller(chroot_path, apt_proxy, environ)` → `Chroot()`

The first instance pops `"switch"` from `MNT_DEFAULT`. The second instance fails because the key is gone.

**Result:** `fab-install` silently fails — `root.build` ends up empty with no packages installed, and the build stamp is created anyway, masking the failure.

## Fix

One-line change: create a shallow copy of the dict before passing to `MagicMounts`:

```python
# Before (mutates global):
self.profile = MNT_DEFAULT if not mnt_profile else mnt_profile

# After (safe copy):
self.profile = dict(MNT_DEFAULT) if not mnt_profile else dict(mnt_profile)
```

## Important note

After applying this fix, **`.pyc` cache files must be cleared**, otherwise Python will continue using the cached bytecode with the old code:

```bash
find /usr/lib/python3/dist-packages/chroot/ -name "*.pyc" -delete
```

## Testing

```python
from chroot import Chroot, MNT_DEFAULT
c1 = Chroot('/tmp')
print(MNT_DEFAULT)  # Before fix: missing 'switch'. After fix: intact.
c2 = Chroot('/tmp')  # Before fix: KeyError. After fix: works.
```