### PR TITLE
fix build issue with resolv.conf

### DIFF
--- a/chroot/__init__.py
+++ b/chroot/__init__.py
@@ -46,10 +46,7 @@ MNT_DEFAULT = {
     "switch": "--type",
     # mount_type/host_mount: mount_point
     "proc": "proc",
-    "sysfs": "sys",
-    "dev": "dev",
     "devpts": "dev/pts",
-    "tmpfs": "run",
 }
 
 MNT_FULL = {


### PR DESCRIPTION
This fixes resolve.conf getting clobbered by tmpfs run mount.

I did a couple iterations but after having issues I resorted to just restoring the old functionality from ~7 months ago. We should circle back to this later and look for a real fix.